### PR TITLE
Use editorconfig

### DIFF
--- a/bin/transync
+++ b/bin/transync
@@ -49,7 +49,7 @@ try {
 var newDictionary = Object.assign({}, fromDictionary, toDictionary)
 var newContent = (path.extname(program.to) === '.json')
   ? JSON.stringify(newDictionary, null, codingStyle.indent_style === 'tab' ? "\t" : codingStyle.indent_size)
-  : yaml.safeDump(newDictionary)
+  : yaml.safeDump(newDictionary, { indent : codingStyle.indent_size })
 
 if(codingStyle.insert_final_newline) {
 	newContent += "\n";

--- a/bin/transync
+++ b/bin/transync
@@ -4,6 +4,7 @@ var program = require('commander')
 var yaml = require('js-yaml')
 var path = require('path')
 var fs = require('fs')
+var editorconfig = require('editorconfig')
 
 program
   .option('-f, --from [from]', 'Base version file for sync')
@@ -20,6 +21,7 @@ if (!program.to) throw new Error('No file specified for --to. Aborting.')
 
 try {
   var fromFile = fs.readFileSync(program.from, 'utf8')
+  var codingStyle = editorconfig.parseSync(program.from)
 } catch (err) {
   throw new Error(`Could not find ‘${program.from}’ file (--from). Aborting.`)
 }
@@ -46,8 +48,12 @@ try {
 
 var newDictionary = Object.assign({}, fromDictionary, toDictionary)
 var newContent = (path.extname(program.to) === '.json')
-  ? JSON.stringify(newDictionary, null, 2)
+  ? JSON.stringify(newDictionary, null, codingStyle.indent_style === 'tab' ? "\t" : codingStyle.indent_size)
   : yaml.safeDump(newDictionary)
+
+if(codingStyle.insert_final_newline) {
+	newContent += "\n";
+}
 
 fs.writeFile(program.to, newContent, 'utf8', function () {
   echo(`Version ‘${program.to}’ correctly synchronized with base version ‘${program.from}’.`)

--- a/package.json
+++ b/package.json
@@ -6,14 +6,21 @@
   "homepage": "https://github.com/edenspiekermann/transync",
   "license": "MIT",
   "author": "Hugo Giraudel <h.giraudel@de.edenspiekermann.com> (www.edenspiekermann.com/people/hugo-giraudel)",
-  "files": ["bin"],
-  "keywords": ["translations", "locales", "sync"],
+  "files": [
+    "bin"
+  ],
+  "keywords": [
+    "translations",
+    "locales",
+    "sync"
+  ],
   "scripts": {
     "pretest": "rm -f tests/de.yml",
     "test": "mocha tests"
   },
   "dependencies": {
     "commander": "^2.9.0",
+    "editorconfig": "^0.13.2",
     "js-yaml": "^3.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Love this project, really nice and simple tool!

I made a small adjustment that adds [editorconfig](https://github.com/editorconfig/editorconfig-core-js) support when generating the yaml and or json files. This will make sure output is in line with a project coding-style.
