### PR TITLE
Support nested keys synchronization and syncing removed keys

### DIFF
--- a/bin/transync
+++ b/bin/transync
@@ -41,13 +41,14 @@ try {
 }
 
 try {
-  var toDictionary = yaml.safeLoad(toFile, { json: true })
+  var toDictionary = toFile === '' ? {} : yaml.safeLoad(toFile, { json: true })
 } catch (err) {
   throw new Error('Could not parse ‘${program.to}’ file (--to). Aborting.')
 }
 
 var JSONindentation = codingStyle.indent_style === 'tab' ? '\t' : codingStyle.indent_size
-var newDictionary = Object.assign({}, fromDictionary, toDictionary)
+var newDictionary = syncDictionaries(fromDictionary, toDictionary)
+
 var newContent = (path.extname(program.to) === '.json')
   ? JSON.stringify(newDictionary, null, JSONindentation)
   : yaml.safeDump(newDictionary, { indent : codingStyle.indent_size })
@@ -59,3 +60,21 @@ if (codingStyle.insert_final_newline) {
 fs.writeFile(program.to, newContent, 'utf8', function () {
   echo(`Version ‘${program.to}’ correctly synchronized with base version ‘${program.from}’.`)
 })
+
+/**
+ * sync translation dictionaries from `from` to `to`.
+ *
+ * this supports nested dictionaries and will remove keys
+ * from the to dictionary that is not in the from dictionary.
+ */
+function syncDictionaries(from, to) {
+  var output = {}
+  for(var key of Object.keys(from)) {
+    if(typeof(from[key]) === 'object') {
+      output[key] = syncDictionaries(from[key], to[key] === undefined ? {} : to[key])
+    } else {
+      output[key] = to[key] === undefined ? from[key] : to[key]
+    }
+  }
+  return output
+}

--- a/bin/transync
+++ b/bin/transync
@@ -48,7 +48,6 @@ try {
 
 var JSONindentation = codingStyle.indent_style === 'tab' ? '\t' : codingStyle.indent_size
 var newDictionary = syncDictionaries(fromDictionary, toDictionary)
-
 var newContent = (path.extname(program.to) === '.json')
   ? JSON.stringify(newDictionary, null, JSONindentation)
   : yaml.safeDump(newDictionary, { indent : codingStyle.indent_size })

--- a/tests/de.json
+++ b/tests/de.json
@@ -1,0 +1,14 @@
+{
+  "animals": {
+    "ant": "Ameise",
+    "bat": "Fledermaus",
+    "cat": "Katze"
+  },
+  "colors": {
+    "white": "weiß",
+    "black": "schwarz",
+    "yellow": "gelb",
+    "pink": "pink"
+  },
+  "winner": "Sieger"
+}

--- a/tests/en.json
+++ b/tests/en.json
@@ -1,0 +1,14 @@
+{
+  "animals": {
+    "ant": "ant",
+    "bat": "bat",
+    "cat": "cat"
+  },
+  "colors": {
+    "white": "white",
+    "black": "black",
+    "yellow": "yellow",
+    "pink" : "pink"
+  },
+  "winner": "winner"
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -12,7 +12,9 @@ describe('The transync script', function () {
     }, Error);
   });
 
-  it('should have the same keys in synced file', function () {
+  it('should have the same keys in synced Yaml file', function () {
+    exec('./bin/transync --from tests/en.yml --to tests/de.yml');
+
     var enContent = fs.readFileSync('tests/en.yml', 'utf8');
     var deContent = fs.readFileSync('tests/de.yml', 'utf8');
     var enKeys = Object.keys(yaml.safeLoad(enContent, { json: true }));
@@ -20,6 +22,36 @@ describe('The transync script', function () {
 
     assert.equal(enKeys.length, deKeys.length);
     assert.deepEqual(enKeys, deKeys);
+  });
+
+  it('should have the same keys in synced Json file', function () {
+  	exec('./bin/transync --from tests/en.json --to tests/de.json');
+
+    var enContent = fs.readFileSync('tests/en.json', 'utf8');
+    var deContent = fs.readFileSync('tests/de.json', 'utf8');
+    var enKeys = Object.keys(JSON.parse(enContent));
+    var deKeys = Object.keys(JSON.parse(deContent));
+
+    assert.equal(enKeys.length, deKeys.length);
+    assert.deepEqual(enKeys, deKeys);
+  });
+
+  it('should remove keys not present in from file', function () {
+    var enContent = fs.readFileSync('tests/en.yml', 'utf8');
+    enContent = yaml.safeLoad(enContent, { json: true });
+    delete enContent.foo
+    enContent = yaml.safeDump(enContent);
+    fs.writeFileSync('tests/en2.yml', enContent, 'utf8');
+
+    exec('./bin/transync --from tests/en2.yml --to tests/de.yml');
+
+    deContent = fs.readFileSync('tests/de.yml', 'utf8');
+    var deObj = yaml.safeLoad(deContent, { json: true });
+
+    assert.equal(deObj.foo, undefined);
+
+    //remove the test file again.
+    fs.unlinkSync('tests/en2.yml');
   });
 
   it('should not override existing keys', function () {


### PR DESCRIPTION
I ran into an issue that a target json file had already a key defined, but that key was an object with translated string, but it was missing some keys from the source file. And also the other way around, when keys were removed from the source, they were not removed from the target.

I've added a function for syncing the dictionaries, using only the keys from the source, adding values from the target if they're defined. If not, the values from the source are added.
