### PR TITLE
Add `src` folder to `files` array for publishing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "author": "Hugo Giraudel <h.giraudel@de.edenspiekermann.com> (www.edenspiekermann.com/people/hugo-giraudel)",
   "files": [
-    "bin"
+    "bin",
+    "src"
   ],
   "keywords": [
     "translations",


### PR DESCRIPTION
Hi Hugo,

I noticed the `src` folder is missing when installing v0.4.0 from the npm registry, so that version is not working at all. In this PR I've added the `src` folder to the `files` array in `package.json`. Although I wasn't able to test if this really solves the issue, but I _guess_ it will.

Cheers,
Alwin
